### PR TITLE
Add templating to make more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# ansible-postgres_exporter
+# ansible-postgres\_exporter
 Postgres exporter
+
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,1 @@
-postgres_exporter_web_listen_address=":9113"
+postgres_exporter_web_listen_address: ":9113"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,1 @@
+postgres_exporter_web_listen_address=":9113"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,24 +6,23 @@
 
 - name: Create user
   user:
-    name: prometheus
+    name: postgres
     state: present
     create_home: no
-    shell: /bin/bash
 
 - name: Make directory
   file:
     path: /opt/postgres_exporter
     state: directory
-    owner: prometheus
-    group: prometheus
+    owner: postgres
+    group: postgres
 
 - name: Make src directory
   file:
     path: /opt/postgres_exporter/src
     state: directory
-    owner: prometheus
-    group: prometheus
+    owner: postgres
+    group: postgres
 
 
 - name: checkout postgres_exporter
@@ -32,7 +31,7 @@
     dest: /opt/postgres_exporter/src/postgres_exporter
     version: matrix.org
   become: true
-  become_user: prometheus
+  become_user: postgres
   vars:
     ansible_ssh_pipelining: true
 
@@ -54,8 +53,8 @@
   template:
     src: queries.yaml.j2
     dest: /opt/postgres_exporter/queries.yaml
-    owner: prometheus
-    group: prometheus
+    owner: postgres
+    group: postgres
   notify:
     - "restart postgres_exporter"
 

--- a/templates/postgres_exporter.service.j2
+++ b/templates/postgres_exporter.service.j2
@@ -5,14 +5,14 @@ Description="Prometheus Postgres Exporter (postgres_exporter)"
 Type=simple
 WorkingDirectory=/opt/postgres_exporter
 # and the award for the most uses of the name of the app in a single commandline goes to:
-ExecStart=/opt/postgres_exporter/src/postgres_exporter/postgres_exporter --web.listen-address=:9113 --extend.query-path="/opt/postgres_exporter/queries.yaml"
-User=prometheus
-Group=prometheus
+ExecStart=/opt/postgres_exporter/src/postgres_exporter/postgres_exporter --web.listen-address={{ postgres_exporter_web_listen_address }} --extend.query-path="/opt/postgres_exporter/queries.yaml"
+User=postgres
+Group=postgres
 Restart=always
 StandardOut=syslog
 SyslogIdentifier=postgres_exporter
 SyslogFacility=local3
-Env=DATA_SOURCE_NAME="host=/tmp dbname=matrix"
+Environment=DATA_SOURCE_NAME="{{ postgres_exporter_data_source_name }}"
 [Install]
 WantedBy=default.target
 


### PR DESCRIPTION
postgres_exporter_data_source_name is actually something for the user of the role to define, not something that should be defaulted.