### PR TITLE
Use upstream v0.8.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,3 @@
 postgres_exporter_web_listen_address: ":9113"
+postgres_exporter_version: "0.8.0"
+postgres_exporter_version_checksum: "sha256:272ed14d3c360579d6e231db34a568ec08f61d2e163cf111e713929ffb6db3f5"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
     dest: /opt/postgres_exporter/queries.yaml
     owner: postgres
     group: postgres
+    mode: "u=rw,g=r,o=r"
   notify:
     - "restart postgres_exporter"
 
@@ -48,6 +49,8 @@
     src: postgres_exporter.service.j2
     dest: /etc/systemd/system/postgres_exporter.service
     owner: root
+    group: root
+    mode: "u=rw,g=r,o=r"
   notify:
     - "reload systemd"
     - "restart postgres_exporter"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,56 +1,38 @@
 ---
-- name: Ensure dependencies installed
-  apt: 
-    name: 
-      - git
-      - make
-      - golang
-    state: present
-
 - name: Create user
   user:
     name: postgres
     state: present
     create_home: no
 
-- name: Make directory
+- name: Make directories
   file:
-    path: /opt/postgres_exporter
+    path: "{{ item }}"
     state: directory
     owner: postgres
     group: postgres
+  loop:
+    - "/opt/postgres_exporter"
+    - "/opt/postgres_exporter/tarballs"
+    - "/opt/postgres_exporter/bin"
 
-- name: Make src directory
-  file:
-    path: /opt/postgres_exporter/src
-    state: directory
+- name: Get postgres_exporter from github
+  get_url:
+    url: https://github.com/wrouesnel/postgres_exporter/releases/download/v{{ postgres_exporter_version }}/postgres_exporter_v{{ postgres_exporter_version }}_linux-amd64.tar.gz
+    dest: /opt/postgres_exporter/tarballs/postgres_exporter-{{ postgres_exporter_version }}.linux-amd64.tar.gz
     owner: postgres
     group: postgres
+    checksum: "{{ postgres_exporter_version_checksum }}"
 
-
-- name: checkout postgres_exporter
-  git:
-    repo: https://github.com/matrix-org/postgres_exporter.git
-    dest: /opt/postgres_exporter/src/postgres_exporter
-    version: matrix.org
-  become: true
-  become_user: postgres
-  vars:
-    ansible_ssh_pipelining: true
-
-- name: Go Get (?)
-  command: go get
-  args:
-    chdir: /opt/postgres_exporter/src/postgres_exporter/
-  environment:
-    GOPATH: /opt/postgres_exporter/
-
-- name: Build
-  make:
-    chdir: /opt/postgres_exporter/src/postgres_exporter/
-    target: binary
-  environment:
-    GOPATH: /opt/postgres_exporter/
+- name: Unpack postgres_exporter into location
+  unarchive:
+    src: /opt/postgres_exporter/tarballs/postgres_exporter-{{ postgres_exporter_version }}.linux-amd64.tar.gz
+    dest: /opt/postgres_exporter/bin/
+    owner: postgres
+    group: postgres
+    remote_src: yes
+  notify:
+    - "restart postgres_exporter"
 
 - name: Template queries.yaml
   template:

--- a/templates/postgres_exporter.service.j2
+++ b/templates/postgres_exporter.service.j2
@@ -5,7 +5,7 @@ Description="Prometheus Postgres Exporter (postgres_exporter)"
 Type=simple
 WorkingDirectory=/opt/postgres_exporter
 # and the award for the most uses of the name of the app in a single commandline goes to:
-ExecStart=/opt/postgres_exporter/src/postgres_exporter/postgres_exporter --web.listen-address={{ postgres_exporter_web_listen_address }} --extend.query-path="/opt/postgres_exporter/queries.yaml"
+ExecStart=/opt/postgres_exporter/bin/postgres_exporter_v{{ postgres_exporter_version}}_linux-amd64/postgres_exporter --web.listen-address={{ postgres_exporter_web_listen_address }} --extend.query-path="/opt/postgres_exporter/queries.yaml"
 User=postgres
 Group=postgres
 Restart=always

--- a/templates/queries.yaml.j2
+++ b/templates/queries.yaml.j2
@@ -215,6 +215,86 @@ pg_statio_all_tables:
         usage: "COUNTER"
         description: "Number of buffer hits in this table's TOAST table indexes (if any)"
 
+# Port of https://github.com/matrix-org/postgres_exporter/commit/f77ce1952e8bdb75b3d36d3be0c604c241f907e6
+pg_stat_all_tables:
+  query: |
+    SELECT relid, schemaname, relname, seq_scan,
+           seq_tup_read, idx_scan, idx_tup_fetch,
+           n_tup_ins, n_tup_upd, n_tup_del,
+           n_tup_hot_upd, n_live_tup, n_dead_tup,
+           n_mod_since_analyze, last_vacuum,
+           last_autovacuum, last_analyze,
+           last_autoanalyze, vacuum_count,
+           autovacuum_count, analyze_count,
+           autoanalyze_count
+    FROM pg_stat_all_tables;
+  metrics:
+    - relid:
+        usage: "LABEL"
+        description: "OID of a table"
+    - schemaname:
+        usage: "LABEL"
+        description: "Name of the schema that this table is in"
+    - relname:
+        usage: "LABEL"
+        description: "Name of this table"
+    - seq_scan:
+        usage: "COUNTER"
+        description: "Number of sequential scans initiated on this table"
+    - seq_tup_read:
+        usage: "COUNTER"
+        description: "Number of live rows fetched by sequential scans"
+    - idx_scan:
+        usage: "COUNTER"
+        description: "Number of index scans initiated on this table"
+    - idx_tup_fetch:
+        usage: "COUNTER"
+        description: "Number of live rows fetched by index scans"
+    - n_tup_ins:
+        usage: "COUNTER"
+        description: "Number of rows inserted"
+    - n_tup_upd:
+        usage: "COUNTER"
+        description: "Number of rows updated"
+    - n_tup_del:
+        usage: "COUNTER"
+        description: "Number of rows deleted"
+    - n_tup_hot_upd:
+        usage: "COUNTER"
+        description: "Number of rows HOT updated (i.e., with no separate index update required)"
+    - n_live_tup:
+        usage: "GAUGE"
+        description: "Estimated number of live rows"
+    - n_dead_tup:
+        usage: "GAUGE"
+        description: "Estimated number of dead rows"
+    - n_mod_since_analyze:
+        usage: "GAUGE"
+        description: "Estimated number of rows modified since this table was last analyzed"
+    - last_vacuum:
+        usage: "COUNTER"
+        description: "Last time at which this table was manually vacuumed (not counting VACUUM FULL)"
+    - last_autovacuum:
+        usage: "COUNTER"
+        description: "Last time at which this table was vacuumed by the autovacuum daemon"
+    - last_analyze:
+        usage: "COUNTER"
+        description: "Last time at which this table was manually analyzed"
+    - last_autoanalyze:
+        usage: "COUNTER"
+        description: "Last time at which this table was analyzed by the autovacuum daemon"
+    - vacuum_count:
+        usage: "COUNTER"
+        description: "Number of times this table has been manually vacuumed (not counting VACUUM FULL)"
+    - autovacuum_count:
+        usage: "COUNTER"
+        description: "Number of times this table has been vacuumed by the autovacuum daemon"
+    - analyze_count:
+        usage: "COUNTER"
+        description: "Number of times this table has been manually analyzed"
+    - autoanalyze_count:
+        usage: "COUNTER"
+        description: "Number of times this table has been analyzed by the autovacuum daemon"
 
 # c.f. https://www.postgresql.org/docs/10/pgstatstatements.html
 pg_stat_statements:

--- a/vagrant-test.yml
+++ b/vagrant-test.yml
@@ -2,3 +2,5 @@
   roles:
     - role: ansible-postgres_exporter
       become: true
+  vars:
+    postgres_exporter_data_source_name: "host=/tmp dbname=postgres"


### PR DESCRIPTION
[Our fork](https://github.com/wrouesnel/postgres_exporter/compare/master...matrix-org:matrix.org#diff-263f1ba3d7567545bb6fde6e24936749L283) changed how `pg_current_wal_lsn` is generated, whereas wrouesnel/postgres_exporter/pull/307 exposed the same value as `pg_current_wal_lsn_bytes`. So we'll need to update any dashboards / alerts

Also remove the need for our fork by pulling https://github.com/matrix-org/postgres_exporter/commit/f77ce1952e8bdb75b3d36d3be0c604c241f907e6 into queries.yaml